### PR TITLE
fix iframeCVH (cdnvideohub) video extraction

### DIFF
--- a/anicli_api/source/yummy_anime.py
+++ b/anicli_api/source/yummy_anime.py
@@ -307,50 +307,46 @@ class Source(BaseSource):
     def get_videos(self, **httpx_kwargs) -> MutableSequence[Video]:
         # TODO: move to anicli-api.player scope
         # https://ru.yummyani.me/iframeCVH.html?dubbing_code=Sanae&anime_id=339&episode=1&dubbing=%D0%9E%D0%B7%D0%B2%D1%83%D1%87%D0%BA%D0%B0+Sanae
-        if "/iframeCVH.html?" in self.url:
-            resp = self.http.get(self.url)
-            base_url = urlsplit(self.url).netloc
-            js_url = self._get_js_url(base_url, resp.text)
-            anime_id, episode, dubbing_code = self._extract_iframe_params(self.url)
-            # WARNING: used brotli encoding algorithm
-            # required httpx[brotli] dependency
-            script = self.http.get(js_url)
-            pub_id, aggr = self._extract_script_params(script.text)
-            resp_api = CdnVideoHubAPI.get_params_from_page(self.http, pub=pub_id, aggr=aggr, id=anime_id)
-            if not resp_api.is_ok:
-                # TODO: handle error
-                return []
-            # search candidate by anime_id, episode_id and dubbing code
-            value = resp_api.value
-            value = cast(CdnVideoHubResponseJson, value)
-            vkid = self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code)
-            if not vkid:
-                return []
-            return self._cdn_videohub_extractor(self.http, vkid=vkid)
-        return super().get_videos(**httpx_kwargs)
+        if "/iframeCVH.html?" not in self.url:
+            return super().get_videos(**httpx_kwargs)
+        resp = self.http.get(self.url)
+        base_url = urlsplit(self.url).netloc
+        js_url = self._get_js_url(base_url, resp.text)
+        anime_id, episode, dubbing_code = self._extract_iframe_params(self.url)
+        # WARNING: used brotli encoding algorithm
+        # required httpx[brotli] dependency
+        script = self.http.get(js_url)
+        pub_id, aggr = self._extract_script_params(script.text)
+        resp_api = CdnVideoHubAPI.get_params_from_page(self.http, pub=pub_id, aggr=aggr, id=anime_id)
+        if not resp_api.is_ok:
+            # TODO: handle error
+            return []
+        # search candidate by anime_id, episode_id and dubbing code
+        value = resp_api.value
+        value = cast(CdnVideoHubResponseJson, value)
+        vkid = self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code)
+        return self._cdn_videohub_extractor(self.http, vkid=vkid) if vkid else []
 
     async def a_get_videos(self, **httpx_kwargs) -> MutableSequence[Video]:
-        if "/iframeCVH.html?" in self.url:
-            resp = await self.http_async.get(self.url)
-            base_url = urlsplit(self.url).netloc
-            js_url = self._get_js_url(base_url, resp.text)
-            anime_id, episode, dubbing_code = self._extract_iframe_params(self.url)
-            script = await self.http_async.get(js_url)
-            pub_id, aggr = self._extract_script_params(script.text)
-            resp_api = await CdnVideoHubAPI.async_get_params_from_page(
-                self.http_async, pub=pub_id, aggr=aggr, id=anime_id
-            )
-            if not resp_api.is_ok:
-                # TODO: handle error
-                return []
-            # search candidate by anime_id, episode_id and dubbing code
-            value = resp_api.value
-            value = cast(CdnVideoHubResponseJson, value)
-            vkid = self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code)
-            if not vkid:
-                return []
+        if "/iframeCVH.html?" not in self.url:
+            return await super().a_get_videos(**httpx_kwargs)
+        resp = await self.http_async.get(self.url)
+        base_url = urlsplit(self.url).netloc
+        js_url = self._get_js_url(base_url, resp.text)
+        anime_id, episode, dubbing_code = self._extract_iframe_params(self.url)
+        script = await self.http_async.get(js_url)
+        pub_id, aggr = self._extract_script_params(script.text)
+        resp_api = await CdnVideoHubAPI.async_get_params_from_page(self.http_async, pub=pub_id, aggr=aggr, id=anime_id)
+        if not resp_api.is_ok:
+            # TODO: handle error
+            return []
+        # search candidate by anime_id, episode_id and dubbing code
+        value = resp_api.value
+        value = cast(CdnVideoHubResponseJson, value)
+        if vkid := self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code):
             return await self._async_cdn_videohub_extractor(self.http_async, vkid=vkid)
-        return await super().a_get_videos(**httpx_kwargs)
+        else:
+            return []
 
 
 if __name__ == "__main__":

--- a/anicli_api/source/yummy_anime.py
+++ b/anicli_api/source/yummy_anime.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Tuple, cast
-from urllib.parse import urlsplit
+from typing import Dict, List, Optional, Tuple, cast
+from urllib.parse import unquote_plus, urlsplit
 
 from attrs import define
 
@@ -270,7 +270,8 @@ class Source(BaseSource):
         anime_id = re.search(r"anime_id=(\d+)", iframe_url)[1]
         episode = re.search(r"episode=(\d+)", iframe_url)[1]
         dubbing_code = re.search(r"dubbing_code=([^&]+)", iframe_url)[1]
-        return int(anime_id), int(episode), dubbing_code
+        # compared as-is with the voiceStudio value, so it must be decoded (cyrillic names, spaces as "+")
+        return int(anime_id), int(episode), unquote_plus(dubbing_code)
 
     @staticmethod
     def _extract_script_params(js_script_response: str) -> Tuple[str, str]:
@@ -295,11 +296,13 @@ class Source(BaseSource):
     @staticmethod
     def _cdnvideohub_extract_vkid_cadidate(
         api_response: CdnVideoHubResponseJson, episode: int, dubbing_code: str
-    ) -> str:
+    ) -> Optional[str]:
         # dubbing_code same value as voiceStudio key
-        return [i for i in api_response["items"] if i["episode"] == int(episode) and i["voiceStudio"] == dubbing_code][
-            0
-        ]["vkId"]
+        # subtitle entries ("voiceType": "Субтитры") come without the voiceStudio key at all
+        candidates = [
+            i for i in api_response["items"] if i["episode"] == int(episode) and i.get("voiceStudio") == dubbing_code
+        ]
+        return candidates[0]["vkId"] if candidates else None
 
     def get_videos(self, **httpx_kwargs) -> MutableSequence[Video]:
         # TODO: move to anicli-api.player scope
@@ -321,6 +324,8 @@ class Source(BaseSource):
             value = resp_api.value
             value = cast(CdnVideoHubResponseJson, value)
             vkid = self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code)
+            if not vkid:
+                return []
             return self._cdn_videohub_extractor(self.http, vkid=vkid)
         return super().get_videos(**httpx_kwargs)
 
@@ -332,7 +337,9 @@ class Source(BaseSource):
             anime_id, episode, dubbing_code = self._extract_iframe_params(self.url)
             script = await self.http_async.get(js_url)
             pub_id, aggr = self._extract_script_params(script.text)
-            resp_api = CdnVideoHubAPI.async_get_params_from_page(self.http_async, pub=pub_id, aggr=aggr, id=anime_id)
+            resp_api = await CdnVideoHubAPI.async_get_params_from_page(
+                self.http_async, pub=pub_id, aggr=aggr, id=anime_id
+            )
             if not resp_api.is_ok:
                 # TODO: handle error
                 return []
@@ -340,6 +347,8 @@ class Source(BaseSource):
             value = resp_api.value
             value = cast(CdnVideoHubResponseJson, value)
             vkid = self._cdnvideohub_extract_vkid_cadidate(value, episode, dubbing_code)
+            if not vkid:
+                return []
             return await self._async_cdn_videohub_extractor(self.http_async, vkid=vkid)
         return await super().a_get_videos(**httpx_kwargs)
 


### PR DESCRIPTION
`Source.get_videos()` for the native `iframeCVH.html` player (ru.yummyani.me) crashed or silently returned nothing for most dubbings.

### 1. `KeyError: 'voiceStudio'`

Subtitle entries in the cdnvideohub response come without the `voiceStudio` key at all:

```json
{"cvhId": "019b0327-...", "vkId": "10746561321686", "voiceType": "Субтитры", "season": 1, "episode": 1}
```

`_cdnvideohub_extract_vkid_cadidate` indexed `i["voiceStudio"]` directly, so the first such entry aborted the whole lookup. For anime_id=52299 that was 12 of 348 items.

### 2. `dubbing_code` was compared while still percent-encoded

`_extract_iframe_params` returned the raw regex capture, so `dubbing_code=%D0%92%D0%B8%D1%81%D1%82%D0%B5%D1%80%D0%B8%D1%8F` was compared against `voiceStudio == "Вистерия"`, and `Brees+Club` against `"Brees Club"`. Only pure-ASCII names without spaces ever matched — 10 of 28 sources on a test episode.

### 3. Missing `await` in `a_get_videos`

`CdnVideoHubAPI.async_get_params_from_page(...)` was called without `await`, so `resp_api.is_ok` ran on a coroutine.

### 4. Empty candidate list

If a dubbing has no cdnvideohub counterpart, the list is empty and `[0]` raised `IndexError`. Now returns `[]`.

## Result

On `anime_id=52299` (Поднятие уровня в одиночку), episode 1: **28/28** CVH sources resolve, was 10/28 with a hard crash on the first one. Verified for both sync and async paths; non-CVH sources still fall through to `super()`.

The second commit is a non-functional refactor of both `get_videos` bodies to guard clauses.
